### PR TITLE
Updating requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ django
 gunicorn
 python-dotenv
 whitenoise
-django-theme-soft-design==1.0.10
+django-theme-soft-design==1.0.06
 
 # psycopg2-binary
 # mysqlclient


### PR DESCRIPTION
`django-theme-soft-design==1.0.10` does not correctly install template pages at `<YOUR_ENV>/LIB/theme_soft_design/template/pages/...`

Once reverted to `django-theme-soft-design==1.0.06` -> templates correctly installed with `pip install -r requirements.txt`